### PR TITLE
ClassInjector.java: Fix a bug where the "final" attribute remained.

### DIFF
--- a/src/main/java/net/uptheinter/interceptify/internal/ClassInjector.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/ClassInjector.java
@@ -242,6 +242,7 @@ class ClassInjector implements ClassFileTransformer {
     }
 
     private void applyModifiersFor(TypeDescription type, List<ModifierContributor> list) {
+        list.add(TypeManifestation.PLAIN);
         if (type.isAnnotation())
             list.add(TypeManifestation.ANNOTATION);
         else if (type.isInterface())
@@ -255,6 +256,7 @@ class ClassInjector implements ClassFileTransformer {
     }
 
     private void applyModifiersFor(MethodDescription method, List<ModifierContributor> list) {
+        list.add(MethodManifestation.PLAIN);
         if (method.isVarArgs())
             list.add(MethodArguments.VARARGS);
         if (method.isStrict())
@@ -272,6 +274,7 @@ class ClassInjector implements ClassFileTransformer {
     }
 
     private void applyModifiersFor(FieldDescription field, List<ModifierContributor> list) {
+        list.add(FieldManifestation.PLAIN);
         if (field.isVolatile())
             list.add(FieldManifestation.VOLATILE);
         if (field.isSynthetic())


### PR DESCRIPTION
In order for the class to be modified properly, we actually need to
first pass PLAIN as a manifestation element. A test has been added that
reproduced the error and now passes with this corrected code.