### PR TITLE
Implement StartupConfig method for checking whether to expose a class.

### DIFF
--- a/src/main/java/net/uptheinter/interceptify/annotations/package-info.java
+++ b/src/main/java/net/uptheinter/interceptify/annotations/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * This package contains the annotations that you should apply to
+ * your own classes and methods for runtime interception.
+ */
+package net.uptheinter.interceptify.annotations;

--- a/src/main/java/net/uptheinter/interceptify/interfaces/StartupConfig.java
+++ b/src/main/java/net/uptheinter/interceptify/interfaces/StartupConfig.java
@@ -61,4 +61,20 @@ public interface StartupConfig {
     default Set<String> makePublic() {
         return new HashSet<>(0);
     }
+
+
+    /**
+     * <p>This function should return true if, after examining the string
+     * parameter, you wish to have that particular class made public.
+     * This is a complimentary option to {@link StartupConfig#makePublic()} -
+     * either of these two can be used to make a class public.</p>
+     * <p>This is called whenever a class is loaded.</p>
+     * <p>The default interface method returns an empty set and does nothing.</p>
+     * @param cls The fully-qualified class name - e.g. {@code foo.bar.MyClass}
+     * @return A Set of fully-qualified class names to make public.
+     */
+    @SuppressWarnings("SameReturnValue")
+    default boolean shouldMakePublic(String cls) {
+        return false;
+    }
 }

--- a/src/main/java/net/uptheinter/interceptify/interfaces/package-info.java
+++ b/src/main/java/net/uptheinter/interceptify/interfaces/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains interfaces you should implement
+ * and pass to
+ * {@link net.uptheinter.interceptify.EntryPoint#entryPoint(net.uptheinter.interceptify.interfaces.StartupConfig,
+ *                                                          java.lang.String[]) EntryPoint.entryPoint}
+ */
+package net.uptheinter.interceptify.interfaces;

--- a/src/main/java/net/uptheinter/interceptify/internal/ClassExposer.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/ClassExposer.java
@@ -1,0 +1,155 @@
+package net.uptheinter.interceptify.internal;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.asm.ModifierAdjustment;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.modifier.EnumerationState;
+import net.bytebuddy.description.modifier.FieldManifestation;
+import net.bytebuddy.description.modifier.FieldPersistence;
+import net.bytebuddy.description.modifier.MethodArguments;
+import net.bytebuddy.description.modifier.MethodManifestation;
+import net.bytebuddy.description.modifier.MethodStrictness;
+import net.bytebuddy.description.modifier.ModifierContributor;
+import net.bytebuddy.description.modifier.Ownership;
+import net.bytebuddy.description.modifier.SynchronizationState;
+import net.bytebuddy.description.modifier.SyntheticState;
+import net.bytebuddy.description.modifier.TypeManifestation;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.pool.TypePool;
+import net.uptheinter.interceptify.util.Boxed;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static net.bytebuddy.matcher.ElementMatchers.is;
+
+class ClassExposer implements ClassFileTransformer {
+    private final ByteBuddy byteBuddy;
+    private final TemporaryByteCodeLocator tempCodeLocator;
+    private final Supplier<TypePool> typePoolSupplier;
+    private final Supplier<ClassFileLocator> locatorSupplier;
+    private Predicate<String> shouldMakePublic = s -> false;
+    private Set<String> toMakePublic = new HashSet<>();
+
+    public ClassExposer(ByteBuddy byteBuddy,
+                        TemporaryByteCodeLocator tempCodeLocator,
+                        Supplier<TypePool> typePoolSupplier,
+                        Supplier<ClassFileLocator> locatorSupplier) {
+        this.byteBuddy = byteBuddy;
+        this.tempCodeLocator = tempCodeLocator;
+        this.typePoolSupplier = typePoolSupplier;
+        this.locatorSupplier = locatorSupplier;
+    }
+
+    public ClassExposer defineMakePublicList(Set<String> toMakePublic) {
+        this.toMakePublic = toMakePublic;
+        return this;
+    }
+
+    public ClassExposer defineMakePublicPredicate(Predicate<String> shouldMakePublic) {
+        this.shouldMakePublic = shouldMakePublic;
+        return this;
+    }
+
+    @Override
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+        if (!toMakePublic.contains(className) && !shouldMakePublic.test(className))
+            return classfileBuffer;
+        return tempCodeLocator.with(className, classfileBuffer, () -> makeAllPublic(className));
+    }
+
+    @Override
+    public byte[] transform(Module module, ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+        return transform(loader, className, classBeingRedefined, protectionDomain, classfileBuffer);
+    }
+
+    private void applyModifiersFor(TypeDescription type, List<ModifierContributor> list) {
+        list.add(TypeManifestation.PLAIN);
+        if (type.isAnnotation())
+            list.add(TypeManifestation.ANNOTATION);
+        else if (type.isInterface())
+            list.add(TypeManifestation.INTERFACE);
+        else if (type.isAbstract())
+            list.add(TypeManifestation.ABSTRACT);
+        if (type.isEnum())
+            list.add(EnumerationState.ENUMERATION);
+        if (type.isStatic())
+            list.add(Ownership.STATIC);
+    }
+
+    private void applyModifiersFor(MethodDescription method, List<ModifierContributor> list) {
+        list.add(MethodManifestation.PLAIN);
+        if (method.isVarArgs())
+            list.add(MethodArguments.VARARGS);
+        if (method.isStrict())
+            list.add(MethodStrictness.STRICT);
+        if (method.isAbstract())
+            list.add(MethodManifestation.ABSTRACT);
+        if (method.isNative())
+            list.add(MethodManifestation.NATIVE);
+        if (method.isBridge())
+            list.add(MethodManifestation.BRIDGE);
+        if (method.isSynchronized())
+            list.add(SynchronizationState.SYNCHRONIZED);
+        if (method.isStatic())
+            list.add(Ownership.STATIC);
+    }
+
+    private void applyModifiersFor(FieldDescription field, TypeDescription cls, List<ModifierContributor> list) {
+        list.add(FieldManifestation.PLAIN);
+        if (field.isVolatile())
+            list.add(FieldManifestation.VOLATILE);
+        if (field.isSynthetic())
+            list.add(SyntheticState.SYNTHETIC);
+        if (field.isTransient())
+            list.add(FieldPersistence.TRANSIENT);
+        if (field.isStatic())
+            list.add(Ownership.STATIC);
+        if (cls.isInterface())
+            list.add(FieldManifestation.FINAL);
+    }
+
+    private <R extends ModifierContributor> List<R> getManifestation(FieldDescription obj, TypeDescription cls) {
+        var ret = new ArrayList<ModifierContributor>(6);
+        ret.add(Visibility.PUBLIC);
+        applyModifiersFor(obj, cls, ret);
+        //noinspection unchecked
+        return (List<R>) ret;
+    }
+
+    private <R extends ModifierContributor, T> List<R> getManifestation(T obj) {
+        var ret = new ArrayList<ModifierContributor>(6);
+        ret.add(Visibility.PUBLIC);
+        if (obj instanceof TypeDescription) {
+            applyModifiersFor((TypeDescription) obj, ret);
+        } else if (obj instanceof MethodDescription) {
+            applyModifiersFor((MethodDescription) obj, ret);
+        }
+        //noinspection unchecked
+        return (List<R>) ret;
+    }
+
+    private byte[] makeAllPublic(String className) {
+        var cls = typePoolSupplier.get().describe(className).resolve();
+        var adjust = new Boxed<>(new ModifierAdjustment());
+        adjust.run(builder -> builder.withTypeModifiers(getManifestation(cls)));
+        cls.getDeclaredMethods().stream()
+                .filter(method -> !method.isPublic() || method.isFinal())
+                .forEach(method -> adjust.run(builder -> builder.withMethodModifiers(is(method), getManifestation(method))));
+        cls.getDeclaredFields().stream()
+                .filter(field -> !field.isPublic() || field.isFinal())
+                .forEach(field -> adjust.run(builder -> builder.withFieldModifiers(is(field), getManifestation(field, cls))));
+        return byteBuddy.redefine(cls, locatorSupplier.get())
+                .visit(adjust.get())
+                .make().getBytes();
+    }
+}

--- a/src/main/java/net/uptheinter/interceptify/internal/RuntimeHook.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/RuntimeHook.java
@@ -1,6 +1,7 @@
 package net.uptheinter.interceptify.internal;
 
 import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
 import net.uptheinter.interceptify.EntryPoint;
 import net.uptheinter.interceptify.interfaces.StartupConfig;
 import net.uptheinter.interceptify.util.JarFiles;
@@ -12,6 +13,10 @@ import java.net.URL;
  * This is the primary point at which intercepting logic kicks off.
  * The class doesn't do all that much now but exists for the purposes
  * of facilitating Java Agent functionality in the future.
+ *
+ * As should be obvious from the package name, this class is internal.
+ * Use EntryPoint for your needs. This class is not subject to semantic
+ * versioning rules as you shouldn't be using it.
  */
 public final class RuntimeHook {
     private static ClassInjector ci;
@@ -30,6 +35,7 @@ public final class RuntimeHook {
         ci
             .setClassPath(classpaths)
             .defineMakePublicList(cfg.makePublic())
+            .defineMakePublicPredicate(cfg::shouldMakePublic)
             .collectMetadataFrom(jarFiles)
             .applyAnnotationsAndIntercept();
     }
@@ -43,6 +49,9 @@ public final class RuntimeHook {
      */
     @SuppressWarnings("unused")
     public static void premain(String args, Instrumentation instr) {
-        ci = new ClassInjector(new ByteBuddy(), instr);
+        var bb = new ByteBuddy();
+        ci = new ClassInjector(args == null || args.isEmpty() ?
+                bb :
+                bb.with(ClassFileVersion.ofJavaVersionString(args)), instr);
     }
 }

--- a/src/main/java/net/uptheinter/interceptify/internal/package-info.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Everything under this package is considered internal to
+ * Interceptify. No semantic versioning rules apply to anything
+ * under here and may be changed arbitrarily without notice since
+ * you shouldn't be using anything in here directly.
+ */
+package net.uptheinter.interceptify.internal;

--- a/src/main/java/net/uptheinter/interceptify/package-info.java
+++ b/src/main/java/net/uptheinter/interceptify/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * <p>Interceptify provides a convenient means of performing runtime class interception.</p>
+ *
+ * <p>The first thing you will want to do is create a class that implements
+ * {@link net.uptheinter.interceptify.interfaces.StartupConfig StartupConfig}</p>
+ *
+ * <p>You will then need to define your own classes to override whatever it is that
+ * you want to hook into. This is achieved through the usage of annotations.
+ * See:
+ * <p>{@link net.uptheinter.interceptify.annotations.InterceptClass @InterceptClass}</p>
+ * <p>{@link net.uptheinter.interceptify.annotations.OverwriteConstructor @OverwriteConsutructor}</p>
+ * <p>{@link net.uptheinter.interceptify.annotations.OverwriteMethod @OverwriteMethod}</p>
+ *
+ * <p>You can also define a list of classes which should be made public, including
+ * their methods and fields. This is of course purely for convenience as you could
+ * achieve the same means through runtime reflection.
+ * There is not yet a formal API for dumping these converted class files - however,
+ * you can fairly easily create your own implementation of {@link java.lang.instrument.Instrumentation Instrumentation}
+ * and pass it to
+ * {@link net.uptheinter.interceptify.EntryPoint#premain(java.lang.String, java.lang.instrument.Instrumentation) EntryPoint.premain}</p>
+ */
+package net.uptheinter.interceptify;

--- a/src/main/java/net/uptheinter/interceptify/util/package-info.java
+++ b/src/main/java/net/uptheinter/interceptify/util/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * This package contains an assortment of convenience
+ * functions which are primarily intended for the benefit
+ * of Interceptify - however, they are considered public
+ * and consequently <b>will</b> honour semantic versioning.
+ */
+package net.uptheinter.interceptify.util;

--- a/src/test/java/net/uptheinter/interceptify/interfaces/TestStartupConfig.java
+++ b/src/test/java/net/uptheinter/interceptify/interfaces/TestStartupConfig.java
@@ -29,4 +29,10 @@ class TestStartupConfig {
         when(conf.makePublic()).thenCallRealMethod();
         assertTrue(conf.makePublic().isEmpty());
     }
+
+    @Test
+    void shouldMakePublic() {
+        when(conf.shouldMakePublic(any())).thenCallRealMethod();
+        assertFalse(conf.shouldMakePublic(null));
+    }
 }

--- a/src/test/java/net/uptheinter/interceptify/internal/TestClassExposer.java
+++ b/src/test/java/net/uptheinter/interceptify/internal/TestClassExposer.java
@@ -1,0 +1,243 @@
+package net.uptheinter.interceptify.internal;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.modifier.EnumerationState;
+import net.bytebuddy.description.modifier.Ownership;
+import net.bytebuddy.description.modifier.TypeManifestation;
+import net.bytebuddy.description.modifier.Visibility;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.loading.ByteArrayClassLoader;
+import net.bytebuddy.pool.TypePool;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class TestClassExposer {
+    final TemporaryByteCodeLocator tempCodeLocator = new TemporaryByteCodeLocator();
+    final ClassFileLocator locator = new ClassFileLocator.Compound(
+            tempCodeLocator,
+            ClassFileLocator.ForClassLoader.ofSystemLoader()
+    );
+    final TypePool typePool = GranularTypePool.of(locator);
+    final ByteBuddy bb = new ByteBuddy();
+
+    @SuppressWarnings({"SameReturnValue", "unused", "EmptyMethod"})
+    private abstract static class toMakePublic {
+        public static final String x = "";
+        private transient volatile char y;
+        protected final int z = 0;
+
+        private static synchronized strictfp boolean a(int x, String y) {
+            return true;
+        }
+
+        public native final int b(char x, int... y);
+
+        protected abstract void c();
+
+        protected final void d() {}
+    }
+
+    @Test
+    void testClassIsMadePublic() throws Exception {
+        String name = "bar.MakePublic";
+        var cls = bb.redefine(toMakePublic.class)
+                .name(name)
+                .modifiers(Ownership.MEMBER, TypeManifestation.ABSTRACT, Visibility.PRIVATE)
+                .noNestMate()
+                .make()
+                .getBytes();
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .defineMakePublicList(new HashSet<>() {{
+                    add(name);
+                }})
+                .transform(null,
+                        ClassLoader.getSystemClassLoader(),
+                        name,
+                        null,
+                        null, cls);
+        var madePublic = new ByteArrayClassLoader(ClassLoader.getSystemClassLoader(),
+                new HashMap<>(){{put(name, arr);}})
+                .loadClass(name);
+        var modifiers = madePublic.getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT, modifiers);
+        modifiers = madePublic.getDeclaredMethod("a", int.class, String.class).getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.STATIC | Modifier.SYNCHRONIZED | Modifier.STRICT, modifiers);
+        modifiers = madePublic.getDeclaredMethod("b", char.class, int[].class).getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.NATIVE | Modifier.TRANSIENT, modifiers);
+        modifiers = madePublic.getDeclaredMethod("c").getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT, modifiers);
+        modifiers = madePublic.getDeclaredMethod("d").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+        modifiers = madePublic.getDeclaredField("x").getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.STATIC, modifiers);
+        modifiers = madePublic.getDeclaredField("y").getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.VOLATILE | Modifier.TRANSIENT, modifiers);
+        modifiers = madePublic.getDeclaredField("z").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+    }
+
+    @SuppressWarnings({"unused", "SameReturnValue"})
+    private interface toMakePublic2 {
+        String s = "";
+        default int x() {
+            return 0;
+        }
+    }
+
+    @Test
+    void testInterfaceIsMadePublic() throws Exception {
+        String name = "bar.MakePublic2";
+        var cls = bb.redefine(toMakePublic2.class)
+                .name(name)
+                .modifiers(Ownership.MEMBER, TypeManifestation.INTERFACE, Visibility.PRIVATE)
+                .noNestMate()
+                .make()
+                .getBytes();
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .defineMakePublicPredicate(name::equals)
+                .transform(null,
+                        ClassLoader.getSystemClassLoader(),
+                        name,
+                        null,
+                        null, cls);
+        var madePublic = new ByteArrayClassLoader(ClassLoader.getSystemClassLoader(),
+                new HashMap<>() {{
+                    put(name, arr);
+                }})
+                .loadClass(name);
+        var modifiers = madePublic.getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.INTERFACE | Modifier.ABSTRACT, modifiers);
+        modifiers = madePublic.getDeclaredMethod("x").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+    }
+
+    @SuppressWarnings({"unused", "EmptyMethod"})
+    private static final class toMakePublic3 {
+        void a() {}
+    }
+
+    @Test
+    void testFinalClassIsMadePublic() throws Exception {
+        String name = "bar.MakePublic3";
+        var cls = bb.redefine(toMakePublic3.class)
+                .name(name)
+                .modifiers(Ownership.MEMBER, TypeManifestation.FINAL, Visibility.PRIVATE)
+                .noNestMate()
+                .make()
+                .getBytes();
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .defineMakePublicList(new HashSet<>() {{
+                    add(name);
+                }})
+                .transform(null,
+                        ClassLoader.getSystemClassLoader(),
+                        name,
+                        null,
+                        null, cls);
+        var madePublic = new ByteArrayClassLoader(ClassLoader.getSystemClassLoader(),
+                new HashMap<>() {{
+                    put(name, arr);
+                }})
+                .loadClass(name);
+        var modifiers = madePublic.getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+        modifiers = madePublic.getDeclaredMethod("a").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+    }
+
+    @SuppressWarnings({"unused", "SameReturnValue", "EmptyMethod"})
+    private enum toMakePublic4 {
+        A,
+        B;
+
+        public final String s = "";
+        public final void x() {}
+        private void y() {}
+    }
+
+    @Test
+    void testEnumIsMadePublic() throws Exception {
+        String name = "bar.MakePublic4";
+        var cls = bb.redefine(toMakePublic4.class)
+                .name(name)
+                .modifiers(Ownership.MEMBER, EnumerationState.ENUMERATION, Visibility.PRIVATE)
+                .noNestMate()
+                .make()
+                .getBytes();
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .defineMakePublicPredicate(name::equals)
+                .transform(null,
+                        ClassLoader.getSystemClassLoader(),
+                        name,
+                        null,
+                        null, cls);
+        var madePublic = new ByteArrayClassLoader(ClassLoader.getSystemClassLoader(),
+                new HashMap<>() {{
+                    put(name, arr);
+                }})
+                .loadClass(name);
+        var modifiers = madePublic.getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers & 0xFFF); // ignore unexposed bits
+        modifiers = madePublic.getDeclaredMethod("x").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+        modifiers = madePublic.getDeclaredMethod("y").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+        modifiers = madePublic.getDeclaredField("s").getModifiers();
+        assertEquals(Modifier.PUBLIC, modifiers);
+        assertTrue(madePublic.isEnum());
+    }
+
+    @SuppressWarnings({"unused", "SameReturnValue"})
+    private @interface toMakePublic5 {
+        String s = "";
+        int x() default 5;
+    }
+
+    @Test
+    void testAnnotationIsMadePublic() throws Exception {
+        String name = "bar.MakePublic5";
+        var cls = bb.redefine(toMakePublic5.class)
+                .name(name)
+                .modifiers(Ownership.MEMBER, TypeManifestation.ANNOTATION, Visibility.PRIVATE)
+                .noNestMate()
+                .make()
+                .getBytes();
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .defineMakePublicPredicate(name::equals)
+                .transform(null,
+                        ClassLoader.getSystemClassLoader(),
+                        name,
+                        null,
+                        null, cls);
+        var madePublic = new ByteArrayClassLoader(ClassLoader.getSystemClassLoader(),
+                new HashMap<>() {{
+                    put(name, arr);
+                }})
+                .loadClass(name);
+        var modifiers = madePublic.getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT | Modifier.INTERFACE, modifiers & 0xFFF); // ignore unexposed bits
+        modifiers = madePublic.getDeclaredMethod("x").getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.ABSTRACT, modifiers);
+        modifiers = madePublic.getDeclaredField("s").getModifiers();
+        assertEquals(Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL, modifiers);
+        assertTrue(madePublic.isAnnotation());
+    }
+
+    @Test
+    void unwantedClassIsIgnored() {
+        var bytes = new byte[1];
+        var arr = new ClassExposer(bb, tempCodeLocator, () -> typePool, () -> locator)
+                .transform(null, ClassLoader.getSystemClassLoader(), "unwanted", null, null, bytes);
+        assertSame(bytes, arr);
+    }
+}

--- a/src/test/java/net/uptheinter/interceptify/internal/TestRuntimeHook.java
+++ b/src/test/java/net/uptheinter/interceptify/internal/TestRuntimeHook.java
@@ -20,7 +20,8 @@ class TestRuntimeHook {
 
     @Test
     void init() throws NoSuchFieldException, IllegalAccessException {
-        RuntimeHook.premain("none", mockInstr);
+        RuntimeHook.premain(null, mockInstr);
+        RuntimeHook.premain("15", mockInstr);
         var ci = RuntimeHook.class.getDeclaredField("ci");
         ci.setAccessible(true);
         ci.set(null, mockInjector);
@@ -29,6 +30,7 @@ class TestRuntimeHook {
         verify(mockConf).getClasspaths();
         verify(mockInjector.setClassPath(any())
                 .defineMakePublicList(any())
+                .defineMakePublicPredicate(any())
                 .collectMetadataFrom(any())).applyAnnotationsAndIntercept();
     }
 }

--- a/src/test/java/net/uptheinter/interceptify/util/TestBoxed.java
+++ b/src/test/java/net/uptheinter/interceptify/util/TestBoxed.java
@@ -17,6 +17,6 @@ class TestBoxed {
     void set() {
         var boxed = new Boxed<>("astr");
         boxed.set("ing");
-        assertEquals(boxed.get(), "ing");
+        assertEquals("ing", boxed.get());
     }
 }


### PR DESCRIPTION
It is now possible to implement a method that is passed the
fully-qualified class string and returns true if that class should be
modified to have itself, its methods and its fields made public and,
where possible, non-final.

Additionally, documentation has been added for all packages to improve
the JavaDoc.