### PR TITLE
Support interception of class instance param using Object type.

### DIFF
--- a/src/main/java/net/uptheinter/interceptify/internal/ParamsAnnotator.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/ParamsAnnotator.java
@@ -15,6 +15,7 @@ import static net.bytebuddy.matcher.ElementMatchers.is;
 
 class ParamsAnnotator {
     private static final String METHODTYPENAME = Method.class.getTypeName();
+    private static final String OBJECTTYPENAME = Object.class.getTypeName();
     private final Boxed<DynamicType.Builder<?>> builderBox;
     private final MethodMetadata method;
     private final MethodMetadata targetMethod;
@@ -38,7 +39,9 @@ class ParamsAnnotator {
     }
 
     private boolean isForThisInstance(ParameterMetadata param) {
-        if (paramIdx != 0 || !param.getTypeName().equals(targetMethod.getDeclaringType().getTypeName()))
+        if (paramIdx != 0 || targetMethod.isStatic() ||
+                !(param.getTypeName().equals(targetMethod.getDeclaringType().getTypeName()) ||
+                  param.getTypeName().equals(OBJECTTYPENAME)))
             return false;
         builderBox.run(builder -> builder.visit(new ForMethod()
                 .annotateParameter(paramIdx++,

--- a/src/main/java/net/uptheinter/interceptify/internal/ParamsValidator.java
+++ b/src/main/java/net/uptheinter/interceptify/internal/ParamsValidator.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 class ParamsValidator {
     private static final String METHODTYPENAME = Method.class.getTypeName();
+    private static final Object OBJECTTYPENAME = Object.class.getTypeName();
     private final MethodMetadata method;
     private final List<ParameterMetadata> params;
     private final ClassMetadata targetedCls;
@@ -38,7 +39,8 @@ class ParamsValidator {
 
     private int validateInstanceMethod(ClassMetadata targetedCls, List<?> otherParams) {
         return (params.size() - 2 != otherParams.size() ||
-                !params.get(0).getTypeName().equals(targetedCls.getTypeName()) ||
+                !(params.get(0).getTypeName().equals(targetedCls.getTypeName()) ||
+                  params.get(0).getTypeName().equals(OBJECTTYPENAME)) ||
                 !params.get(1).getTypeName().equals(METHODTYPENAME)) ? -1 : 2;
     }
 

--- a/src/test/java/net/uptheinter/interceptify/internal/TestParamsValidator.java
+++ b/src/test/java/net/uptheinter/interceptify/internal/TestParamsValidator.java
@@ -25,6 +25,9 @@ class TestParamsValidator {
         static void Good3(int c, char d) {}
         static void Chek3(int c, char d) {}
 
+        static void Good4(Object a, Method b, String c, float d) {}
+        void Chek4(String c, float d) {}
+
         void Bad1(TestMe a, Method b, int c) {}
         void Chk1(int c) {}
 
@@ -75,6 +78,7 @@ class TestParamsValidator {
         assertTrue(new ParamsValidator(getMethod(cls, "Good1"), cm).isCompatible(getMethod(cls, "Chek1")));
         assertTrue(new ParamsValidator(getMethod(cls, "Good2"), cm).isCompatible(getMethod(cls, "Chek2")));
         assertTrue(new ParamsValidator(getMethod(cls, "Good3"), cm).isCompatible(getMethod(cls, "Chek3")));
+        assertTrue(new ParamsValidator(getMethod(cls, "Good4"), cm).isCompatible(getMethod(cls, "Chek4")));
 
         assertFalse(new ParamsValidator(getMethod(cls, "Bad1"), cm).isCompatible(getMethod(cls, "Chk1")));
         assertFalse(new ParamsValidator(getMethod(cls, "Bad2"), cm).isCompatible(getMethod(cls, "Chk2")));


### PR DESCRIPTION
In order to support scenarios where the intercepting code cannot
directly declare the type of the class to be intercepted, we now support
methods which accept an Object as their first parameter.